### PR TITLE
PostGIS getAll functions not returning final item returned from DB

### DIFF
--- a/wikibrain-spatial/src/main/java/org/wikibrain/spatial/dao/postgis/PostGISDB.java
+++ b/wikibrain-spatial/src/main/java/org/wikibrain/spatial/dao/postgis/PostGISDB.java
@@ -271,12 +271,12 @@ public class PostGISDB {
             iterator.close();
             return null;
         }
-        Feature feature = iterator.next();
+        Feature feature;
 
         Map<Integer, Geometry> geometries = new HashMap<Integer, Geometry>();
         while (iterator.hasNext()){
-            geometries.put((Integer)((SimpleFeatureImpl)feature).getAttribute("item_id"), (Geometry) feature.getDefaultGeometryProperty().getValue());
             feature = iterator.next();
+            geometries.put((Integer)((SimpleFeatureImpl)feature).getAttribute("item_id"), (Geometry) feature.getDefaultGeometryProperty().getValue());
         }
         iterator.close();
         return geometries;
@@ -333,12 +333,12 @@ public class PostGISDB {
                 return null;
             }
 
-            Feature feature = iterator.next();
+            Feature feature;
 
             Map<Integer, Geometry> geometries = new HashMap<Integer, Geometry>();
             while (iterator.hasNext()){
-                geometries.put((Integer)((SimpleFeatureImpl)feature).getAttribute("item_id"), (Geometry) feature.getDefaultGeometryProperty().getValue());
                 feature = iterator.next();
+                geometries.put((Integer)((SimpleFeatureImpl)feature).getAttribute("item_id"), (Geometry) feature.getDefaultGeometryProperty().getValue());
             }
             iterator.close();
             return geometries;


### PR DESCRIPTION
The current iterator does not add the final iterator.next() Feature to the geometries HashMap. Restructured iterator so all items returned. Noticed this in two functions for PostGISDB but not sure where else this logic might be in effect.