### PR TITLE
GUI Loader overlaps the taskbar- Cannot click "Run" loader

### DIFF
--- a/wikibrain-loader/src/main/java/org/wikibrain/loader/GraphicLoader.java
+++ b/wikibrain-loader/src/main/java/org/wikibrain/loader/GraphicLoader.java
@@ -82,7 +82,7 @@ public class GraphicLoader extends JFrame {
     public GraphicLoader() {
         super();
         this.setSize(1000, 600);
-        this.setResizable(false);
+        this.setResizable(true);
         this.setLocationRelativeTo(null);
         this.setTitle("WikiBrain Configuration");
 
@@ -321,6 +321,7 @@ public class GraphicLoader extends JFrame {
         gbc.weighty = 0.9;
         JScrollPane jsp = new JScrollPane(cmdText);
         jsp.setPreferredSize(new Dimension(300, 300));
+        jsp.setMinimumSize(new Dimension(300,300));
         jsp.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
         jsp.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
 


### PR DESCRIPTION
I could not click the "Run" button because the taskbar overlapped it (maybe because my screen resolution is low-1366x728 ?) Can be solved if we make the loader resizeable, and set the cmdLine scrollPane to a fixed size. 

## Before
![error](https://user-images.githubusercontent.com/25305892/37635560-8080ffd0-2bb9-11e8-9477-446b6a497a43.png)
## After 
![error2](https://user-images.githubusercontent.com/25305892/37635564-854e0ecc-2bb9-11e8-8538-844ba117decc.png)

:-)
